### PR TITLE
feat(version): enhanced version cmd

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -32,9 +32,11 @@ var (
 	exampleFlag string // Target a specific example instead of the module (init, fmt, validate)
 )
 
-// versionTemplate returns the version string with commit and date
+// versionTemplate returns the version string with commit and date.
+// It uses ldflags values if set, otherwise falls back to Go build info.
 func versionTemplate() string {
-	return fmt.Sprintf("motf version %s\ncommit: %s\nbuilt:  %s\n", version, commit, date)
+	v, c, d := effectiveVersion()
+	return fmt.Sprintf("motf version %s\ncommit: %s\nbuilt:  %s\n", v, c, d)
 }
 
 // rootCmd represents the base command

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"runtime/debug"
 	"strings"
 	"testing"
 )
@@ -79,5 +80,199 @@ func TestVersionTemplate_Format(t *testing.T) {
 	// Third line should start with "built:"
 	if !strings.HasPrefix(lines[2], "built:") {
 		t.Errorf("third line should start with 'built:', got: %s", lines[2])
+	}
+}
+
+// mockBuildInfo returns a function that can be assigned to readBuildInfo for testing
+func mockBuildInfo(info *debug.BuildInfo, ok bool) func() (*debug.BuildInfo, bool) {
+	return func() (*debug.BuildInfo, bool) {
+		return info, ok
+	}
+}
+
+func TestEffectiveVersion_LdflagsWin(t *testing.T) {
+	// Save and restore globals
+	origVersion, origCommit, origDate := version, commit, date
+	origReadBuildInfo := readBuildInfo
+	defer func() {
+		version, commit, date = origVersion, origCommit, origDate
+		readBuildInfo = origReadBuildInfo
+	}()
+
+	// Set ldflags values (non-defaults)
+	version = "v1.2.3"
+	commit = "abc123"
+	date = "2026-01-01T00:00:00Z"
+
+	// Mock build info with different values
+	readBuildInfo = mockBuildInfo(&debug.BuildInfo{
+		Main: debug.Module{Version: "v9.9.9"},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "zzz999"},
+			{Key: "vcs.time", Value: "2099-12-31T23:59:59Z"},
+		},
+	}, true)
+
+	v, c, d := effectiveVersion()
+
+	// ldflags should win
+	if v != "v1.2.3" {
+		t.Errorf("version: got %q, want %q", v, "v1.2.3")
+	}
+	if c != "abc123" {
+		t.Errorf("commit: got %q, want %q", c, "abc123")
+	}
+	if d != "2026-01-01T00:00:00Z" {
+		t.Errorf("date: got %q, want %q", d, "2026-01-01T00:00:00Z")
+	}
+}
+
+func TestEffectiveVersion_FallbackToModuleVersion(t *testing.T) {
+	origVersion, origCommit, origDate := version, commit, date
+	origReadBuildInfo := readBuildInfo
+	defer func() {
+		version, commit, date = origVersion, origCommit, origDate
+		readBuildInfo = origReadBuildInfo
+	}()
+
+	// Defaults (ldflags not set)
+	version, commit, date = "dev", "none", "unknown"
+
+	// Mock build info with module version only
+	readBuildInfo = mockBuildInfo(&debug.BuildInfo{
+		Main: debug.Module{Version: "v0.4.0"},
+	}, true)
+
+	v, c, d := effectiveVersion()
+
+	if v != "v0.4.0" {
+		t.Errorf("version: got %q, want %q", v, "v0.4.0")
+	}
+	// commit/date stay default when VCS info not available
+	if c != "none" {
+		t.Errorf("commit: got %q, want %q", c, "none")
+	}
+	if d != "unknown" {
+		t.Errorf("date: got %q, want %q", d, "unknown")
+	}
+}
+
+func TestEffectiveVersion_FallbackToVCSInfo(t *testing.T) {
+	origVersion, origCommit, origDate := version, commit, date
+	origReadBuildInfo := readBuildInfo
+	defer func() {
+		version, commit, date = origVersion, origCommit, origDate
+		readBuildInfo = origReadBuildInfo
+	}()
+
+	version, commit, date = "dev", "none", "unknown"
+
+	readBuildInfo = mockBuildInfo(&debug.BuildInfo{
+		Main: debug.Module{Version: "v0.5.0"},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "deadbeef1234"},
+			{Key: "vcs.time", Value: "2026-01-26T10:00:00Z"},
+		},
+	}, true)
+
+	v, c, d := effectiveVersion()
+
+	if v != "v0.5.0" {
+		t.Errorf("version: got %q, want %q", v, "v0.5.0")
+	}
+	if c != "deadbeef1234" {
+		t.Errorf("commit: got %q, want %q", c, "deadbeef1234")
+	}
+	if d != "2026-01-26T10:00:00Z" {
+		t.Errorf("date: got %q, want %q", d, "2026-01-26T10:00:00Z")
+	}
+}
+
+func TestEffectiveVersion_ModifiedSuffix(t *testing.T) {
+	origVersion, origCommit, origDate := version, commit, date
+	origReadBuildInfo := readBuildInfo
+	defer func() {
+		version, commit, date = origVersion, origCommit, origDate
+		readBuildInfo = origReadBuildInfo
+	}()
+
+	version, commit, date = "dev", "none", "unknown"
+
+	readBuildInfo = mockBuildInfo(&debug.BuildInfo{
+		Main: debug.Module{Version: "v0.6.0"},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "abc123"},
+			{Key: "vcs.modified", Value: "true"},
+		},
+	}, true)
+
+	v, c, _ := effectiveVersion()
+
+	if v != "v0.6.0" {
+		t.Errorf("version: got %q, want %q", v, "v0.6.0")
+	}
+	if c != "abc123 (modified)" {
+		t.Errorf("commit: got %q, want %q", c, "abc123 (modified)")
+	}
+}
+
+func TestEffectiveVersion_DevelVersionKeptAsDev(t *testing.T) {
+	origVersion, origCommit, origDate := version, commit, date
+	origReadBuildInfo := readBuildInfo
+	defer func() {
+		version, commit, date = origVersion, origCommit, origDate
+		readBuildInfo = origReadBuildInfo
+	}()
+
+	version, commit, date = "dev", "none", "unknown"
+
+	// Local build: Main.Version is "(devel)"
+	readBuildInfo = mockBuildInfo(&debug.BuildInfo{
+		Main: debug.Module{Version: "(devel)"},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "localcommit"},
+			{Key: "vcs.time", Value: "2026-01-26T12:00:00Z"},
+		},
+	}, true)
+
+	v, c, d := effectiveVersion()
+
+	// Version stays "dev" because (devel) is not useful
+	if v != "dev" {
+		t.Errorf("version: got %q, want %q", v, "dev")
+	}
+	// But commit/date can still be filled from VCS
+	if c != "localcommit" {
+		t.Errorf("commit: got %q, want %q", c, "localcommit")
+	}
+	if d != "2026-01-26T12:00:00Z" {
+		t.Errorf("date: got %q, want %q", d, "2026-01-26T12:00:00Z")
+	}
+}
+
+func TestEffectiveVersion_NoBuildInfo(t *testing.T) {
+	origVersion, origCommit, origDate := version, commit, date
+	origReadBuildInfo := readBuildInfo
+	defer func() {
+		version, commit, date = origVersion, origCommit, origDate
+		readBuildInfo = origReadBuildInfo
+	}()
+
+	version, commit, date = "dev", "none", "unknown"
+
+	// Build info not available
+	readBuildInfo = mockBuildInfo(nil, false)
+
+	v, c, d := effectiveVersion()
+
+	// All defaults remain
+	if v != "dev" {
+		t.Errorf("version: got %q, want %q", v, "dev")
+	}
+	if c != "none" {
+		t.Errorf("commit: got %q, want %q", c, "none")
+	}
+	if d != "unknown" {
+		t.Errorf("date: got %q, want %q", d, "unknown")
 	}
 }


### PR DESCRIPTION
This pull request enhances the application's version reporting by introducing logic to prefer version, commit, and build date information provided via ldflags, but gracefully falls back to Go module build info when ldflags are unset. It also adds comprehensive unit tests to ensure this logic works correctly across various scenarios.

Version reporting improvements:

* Added the `effectiveVersion` function in `helpers.go` to determine version, commit, and date, preferring ldflags values but falling back to Go build info (`debug.ReadBuildInfo`) when necessary. Helper functions were introduced to extract module and VCS information, including handling for modified working trees.
* Updated the `versionTemplate` function in `root.go` to use the new `effectiveVersion` logic, ensuring the version output always reflects the most accurate information available.

Testing enhancements:

* Added extensive tests in `version_test.go` covering scenarios for ldflags presence, module-only version, VCS info fallback, modified working tree, local "(devel)" builds, and missing build info. A mock for `debug.ReadBuildInfo` was introduced to facilitate these tests.
* Imported `runtime/debug` in both `helpers.go` and `version_test.go` to support reading and mocking build info [[1]](diffhunk://#diff-6424733c1b3591f07fb95b78918927331a746eef0fe1f47b81a293f6d3247d8cR7-R64) [[2]](diffhunk://#diff-e460a937d16e0fec938fe165c0b2665f7d1e9af87946efceb67505b43aefd67dR5).