### PR TITLE
Rename 'show' command to 'get'

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@
 cmd/
   motf/        → Main entrypoint (imports internal/cli)
 internal/
-  cli/         → Cobra CLI commands (root.go, init.go, fmt.go, validate.go, test.go, list.go, show.go)
+  cli/         → Cobra CLI commands (root.go, init.go, fmt.go, validate.go, test.go, list.go, get.go)
   config/      → .motf.yml configuration loading and validation
   finder/      → Module discovery via recursive directory walking
   terraform/   → Terraform/tofu command execution wrapper
@@ -46,7 +46,7 @@ cd e2e && go test -v
 
 # Quick manual test against demo
 ./motf list          # from repo root with demo/ present
-./motf show storage-account
+./motf get storage-account
 ```
 
 ## Code Conventions

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ A command-line tool for working with Terraform monorepos. `motf` (pronounced `mo
 ## Features
 
 - **Simple commands**: Run `init`, `fmt`, `validate`, and `test` on components, bases, or projects
-- **Module inspection**: Use `show` to view detailed module information including submodules, tests, and examples
+- **Module inspection**: Use `get` to view detailed module information including submodules, tests, and examples
 - **Example targeting**: Run commands on specific examples within modules using the `-e` flag
 - **Configurable**: Support for both `terraform` and `tofu` via `.motf.yml`
 - **Test support**: Run terratests or native terraform/tofu tests on modules
 - **Smart discovery**: Recursively finds modules in nested subdirectories
 - **Clash detection**: Warns when multiple modules share the same name
-- **JSON output**: Use `--json` flag with `list` and `show` for scripting
+- **JSON output**: Use `--json` flag with `list` and `get` for scripting
 
 ## Installation
 
@@ -98,13 +98,13 @@ Test configuration:
   Args:   (none)
 ```
 
-#### `motf show`
-Show detailed information about a module:
+#### `motf get`
+Get detailed information about a module:
 
 ```bash
-motf show storage-account      # Show details for storage-account
-motf show --path ./my-module   # Show details for module at explicit path
-motf show storage-account --json  # Output as JSON for scripting
+motf get storage-account      # Get details for storage-account
+motf get --path ./my-module   # Get details for module at explicit path
+motf get storage-account --json  # Output as JSON for scripting
 ```
 
 Output:
@@ -143,7 +143,7 @@ motf list --json             # Output as JSON for scripting
 | `--example` | `-e` | Run on a specific example instead of the module (for `init`, `fmt`, `val`) |
 | `--args` | `-a` | Extra arguments to pass to terraform/tofu (can be specified multiple times) |
 | `--search` | `-s` | Filter modules using wildcards (for `list`) |
-| `--json` | | Output in JSON format (for `list` and `show`) |
+| `--json` | | Output in JSON format (for `list` and `get`) |
 | `--version` | `-v` | Show version |
 | `--help` | `-h` | Show help |
 
@@ -175,9 +175,9 @@ motf init spacelift-modules
 # Pass extra arguments
 motf init storage-account -a -upgrade -a -reconfigure
 
-# Show module details
-motf show storage-account
-motf show storage-account --json
+# Get module details
+motf get storage-account
+motf get storage-account --json
 
 # List all modules
 motf list

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -101,7 +101,7 @@ func TestRootCmd_HasArgsFlag(t *testing.T) {
 
 func TestAllCommandsRegistered(t *testing.T) {
 	commands := rootCmd.Commands()
-	expectedCmds := []string{"init", "fmt", "val", "test", "list", "show", "config"}
+	expectedCmds := []string{"init", "fmt", "val", "test", "list", "get", "config"}
 
 	cmdMap := make(map[string]bool)
 	for _, cmd := range commands {

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -12,29 +12,29 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// showJsonFlag controls JSON output for show command
-var showJsonFlag bool
+// getJsonFlag controls JSON output for get command
+var getJsonFlag bool
 
-// showCmd represents the show command
-var showCmd = &cobra.Command{
-	Use:   "show [module-name]",
-	Short: "Show details about a component, base, or project",
-	Long: `Show detailed information about a module including its type, path,
+// getCmd represents the get command
+var getCmd = &cobra.Command{
+	Use:   "get [module-name]",
+	Short: "Get details about a component, base, or project",
+	Long: `Get detailed information about a module including its type, path,
 whether it has submodules, tests, examples, and its Spacelift registry version.
 
 Use the --json flag to output in JSON format for scripting.
 
 Examples:
-  motf show storage-account      # Show details for storage-account
-  motf show --path ./my-module   # Show details for module at explicit path
-  motf show storage-account --json  # Output as JSON`,
+  motf get storage-account      # Get details for storage-account
+  motf get --path ./my-module   # Get details for module at explicit path
+  motf get storage-account --json  # Output as JSON`,
 	Args: cobra.MaximumNArgs(1),
-	RunE: runShow,
+	RunE: runGet,
 }
 
 func init() {
-	showCmd.Flags().BoolVar(&showJsonFlag, "json", false, "Output in JSON format")
-	rootCmd.AddCommand(showCmd)
+	getCmd.Flags().BoolVar(&getJsonFlag, "json", false, "Output in JSON format")
+	rootCmd.AddCommand(getCmd)
 }
 
 // ModuleDetails contains detailed information about a module
@@ -57,7 +57,7 @@ type ItemInfo struct {
 	Path string `json:"path"`
 }
 
-func runShow(cmd *cobra.Command, args []string) error {
+func runGet(cmd *cobra.Command, args []string) error {
 	targetPath, err := resolveTargetPath(args)
 	if err != nil {
 		return err
@@ -68,7 +68,7 @@ func runShow(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if showJsonFlag {
+	if getJsonFlag {
 		return printModuleDetailsJSON(details)
 	}
 

--- a/internal/cli/get_test.go
+++ b/internal/cli/get_test.go
@@ -522,7 +522,7 @@ func TestGetModuleDetails_EmptyDirectories(t *testing.T) {
 	}
 }
 
-func TestShowCommand_Integration(t *testing.T) {
+func TestGetCommand_Integration(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	cfg = &config.Config{Root: "", Binary: "terraform"}
@@ -588,7 +588,7 @@ func TestShowCommand_Integration(t *testing.T) {
 	}
 }
 
-// Edge case tests for show command
+// Edge case tests for get command
 
 func TestGetModuleDetails_NoSubdirectories(t *testing.T) {
 	tmpDir := t.TempDir()


### PR DESCRIPTION
This pull request renames the `show` command to `get` throughout the codebase and documentation to better reflect its purpose of retrieving detailed module information. All references, tests, and documentation have been updated to use the new command name.

**Command and Codebase Updates:**

* Renamed the CLI command from `show` to `get`, including all related code in `internal/cli/show.go` (now `get.go`) and associated flags, functions, and command registration. [[1]](diffhunk://#diff-4d8ec7a568ee2f799536067eb9f5d22781f1d3cc38e77782212a3ac4ba8896c0L15-R37) [[2]](diffhunk://#diff-4d8ec7a568ee2f799536067eb9f5d22781f1d3cc38e77782212a3ac4ba8896c0L60-R60) [[3]](diffhunk://#diff-4d8ec7a568ee2f799536067eb9f5d22781f1d3cc38e77782212a3ac4ba8896c0L71-R71)
* Updated tests to reflect the new `get` command, renaming test files and test function names accordingly. [[1]](diffhunk://#diff-75a5ee790679afaa970834a8092580bd9a3e77aa784477ed85f2a1bde6ba1384L525-R525) [[2]](diffhunk://#diff-75a5ee790679afaa970834a8092580bd9a3e77aa784477ed85f2a1bde6ba1384L591-R591)
* Modified the list of registered commands in `TestAllCommandsRegistered` to include `get` instead of `show`.

**Documentation Updates:**

* Changed all documentation references from `show` to `get` in `README.md`, including usage examples, feature descriptions, and flag documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L101-R107) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L146-R146) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L178-R180)
* Updated the project structure and usage instructions in `.github/copilot-instructions.md` to use `get` instead of `show`. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L13-R13) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L49-R49)