### PR TITLE
Add --example flag to run tasks on specific examples

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -458,6 +458,7 @@ See [Configuration](configuration#custom-tasks) for how to define tasks.
 |------|-------|-------------|
 | `--task` | `-t` | Name of the task to run |
 | `--list` | `-l` | List available tasks |
+| `--example` | `-e` | Run on a specific example instead of the module |
 | `--changed` | | Run task on all modules changed compared to `--ref` |
 | `--ref` | | Git ref to compare against (default: auto-detect) |
 | `--parallel` | `-p` | Run commands in parallel across modules |
@@ -471,6 +472,9 @@ motf task --list
 
 # Run a specific task
 motf task storage-account --task lint
+
+# Run a task on an example
+motf task storage-account -t lint -e basic
 
 # Run task on explicit path
 motf task --path ./modules/x --task docs

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -27,6 +27,7 @@ Examples:
   motf task storage-account --list             # List available tasks
   motf task storage-account -t hello-world     # Run 'hello-world' task
   motf task storage-account --task lint        # Run 'lint' task
+  motf task storage-account -t lint -e basic   # Run 'lint' task on 'basic' example
   motf task --path ./modules/x -t docs         # Run task on explicit path
   motf task -t lint --changed                  # Run 'lint' task on changed modules
   motf task -t lint --changed --parallel       # Run 'lint' task on changed modules in parallel`,
@@ -38,6 +39,9 @@ Examples:
 		}
 
 		if changedFlag {
+			if exampleFlag != "" {
+				return fmt.Errorf("--changed cannot be used with --example")
+			}
 			if len(args) > 0 {
 				return cobra.MaximumNArgs(0)(cmd, args)
 			}
@@ -47,8 +51,8 @@ Examples:
 			})
 		}
 
-		// Resolve module path
-		targetPath, err := resolveTargetPath(args)
+		// Resolve module path (with optional example)
+		targetPath, err := resolveTargetWithExample(args, exampleFlag)
 		if err != nil {
 			return err
 		}
@@ -88,6 +92,7 @@ func listTasks() error {
 func init() {
 	taskCmd.Flags().StringVarP(&taskFlag, "task", "t", "", "Task name to run")
 	taskCmd.Flags().BoolVarP(&listTaskFlag, "list", "l", false, "List available tasks")
+	taskCmd.Flags().StringVarP(&exampleFlag, "example", "e", "", "Run on a specific example instead of the module")
 	taskCmd.Flags().BoolVar(&changedFlag, "changed", false, "Run on modules changed compared to --ref")
 	taskCmd.Flags().StringVar(&refFlag, "ref", "", "Git ref for --changed (default: auto-detect from origin/HEAD)")
 	taskCmd.Flags().BoolVarP(&parallelFlag, "parallel", "p", false, "Run commands in parallel")

--- a/internal/cli/task_test.go
+++ b/internal/cli/task_test.go
@@ -20,4 +20,12 @@ func TestTaskCmd_Flags(t *testing.T) {
 	if listFlagDef.Shorthand != "l" {
 		t.Errorf("list flag shorthand = %q, want %q", listFlagDef.Shorthand, "l")
 	}
+
+	exampleFlagDef := taskCmd.Flags().Lookup("example")
+	if exampleFlagDef == nil {
+		t.Fatal("task command should have --example flag")
+	}
+	if exampleFlagDef.Shorthand != "e" {
+		t.Errorf("example flag shorthand = %q, want %q", exampleFlagDef.Shorthand, "e")
+	}
 }


### PR DESCRIPTION
This pull request introduces support for running tasks on specific examples within a module using a new `--example` (`-e`) flag. It updates the CLI, documentation, and adds comprehensive end-to-end and unit tests for this feature. The implementation also ensures that `--example` cannot be used together with `--changed`, and provides clear error messages for invalid usage.

**Feature: Run tasks on module examples**
- Added a new `--example` (`-e`) flag to the `motf task` command, allowing users to run a task on a specific example within a module instead of the module root. This is reflected in the CLI, help text, and documentation. [[1]](diffhunk://#diff-c7726c8ab24b758a1e6fdf229f638787343c4286a688cf448767c5e6c5e8af0bR95) [[2]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eR461) [[3]](diffhunk://#diff-c7726c8ab24b758a1e6fdf229f638787343c4286a688cf448767c5e6c5e8af0bR30) [[4]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eR476-R478)

**Error handling and validation**
- Enforced that `--changed` and `--example` cannot be used together, returning a clear error if both flags are provided.
- Improved error messages for cases where a specified example does not exist.

**Testing**
- Added end-to-end tests to verify running tasks on examples, handling of non-existent examples, and conflicting flag usage.
- Updated unit tests to check for the presence and shorthand of the new `--example` flag.

**Implementation**
- Updated internal logic to resolve the target path with the optional example flag, ensuring tasks are executed in the correct directory.

closes #36 