### PR TITLE
feat: add script to sync copilot instructions from claude.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,5 @@
+<!-- AUTO-GENERATED FROM .claude/claude.md. DO NOT EDIT DIRECTLY. -->
+
 # Copilot Instructions for motf
 
 ## Project Overview

--- a/.github/scripts/sync-copilot-instructions.sh
+++ b/.github/scripts/sync-copilot-instructions.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SRC=".claude/claude.md"
+DST=".github/copilot-instructions.md"
+
+if [[ ! -f "$SRC" ]]; then
+  echo "Missing source file: $SRC" >&2
+  exit 1
+fi
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+{
+  echo "<!-- AUTO-GENERATED FROM .claude/claude.md. DO NOT EDIT DIRECTLY. -->"
+  echo
+  cat "$SRC"
+} > "$tmp"
+
+if [[ ! -f "$DST" ]] || ! cmp -s "$tmp" "$DST"; then
+  mkdir -p "$(dirname "$DST")"
+  mv "$tmp" "$DST"
+  echo "Updated $DST from $SRC"
+  echo "Please stage $DST and commit again."
+  exit 1
+fi
+
+echo "$DST is already in sync with $SRC"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,16 @@
 # See https://pre-commit.com for more information
 # See https://github.com/TekWizely/pre-commit-golang for Go hooks
 repos:
+  # Local hooks
+  - repo: local
+    hooks:
+      - id: sync-copilot-instructions
+        name: Sync copilot instructions from claude.md
+        entry: bash .github/scripts/sync-copilot-instructions.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+
   # Standard pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0


### PR DESCRIPTION
This pull request introduces automation to keep the `copilot-instructions.md` file in sync with the canonical `claude.md` file, ensuring documentation consistency. It does so by adding a script and integrating it into the pre-commit workflow.

**Automation of documentation sync:**

* Added a new script (`.github/scripts/sync-copilot-instructions.sh`) that auto-generates `.github/copilot-instructions.md` from `.claude/claude.md`, including a warning header not to edit the generated file directly.
* Updated `.pre-commit-config.yaml` to include a local pre-commit hook that runs the sync script automatically before each commit, ensuring the instructions file stays up to date.

**Documentation update:**

* Added an auto-generated comment at the top of `.github/copilot-instructions.md` to indicate the file should not be edited directly.