### PR TITLE
Fix test command to discover and run tests in skipped folders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26.x'
           cache: true
 
       - name: Run golangci-lint
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26.x'
           cache: true
 
       - name: Run govulncheck
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26.x'
           cache: true
 
       - name: Set up Terraform # Used to test terraform binary compatibility
@@ -97,7 +97,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26.x'
           cache: true
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26.x'
           cache: true
 
       - name: Run GoReleaser

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26.x'
           cache: true
 
       - name: Set up Terraform

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/TechnicallyJoe/terraform-motf
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-git/go-git/v5 v5.19.0

--- a/internal/cli/changed_runner.go
+++ b/internal/cli/changed_runner.go
@@ -132,10 +132,20 @@ func resolveChangedModules(basePath, repoRoot string, changedPaths []string) []M
 		absPath := filepath.Join(repoRoot, modulePath)
 
 		// Check if this directory contains terraform files
-		if !finder.HasTerraformFiles(absPath) {
-			// The changed file might be in a subdirectory (like tests/ or examples/)
-			// Walk up to find the actual module
-			absPath = findParentModule(absPath, basePath)
+		hasTF := finder.HasTerraformFiles(absPath)
+
+		// Even if the directory has .tf files, if it's inside a skipDir
+		// (e.g. examples/basic), it's not a standalone module — walk up.
+		inSkipDir := finder.PathContainsSkipDir(modulePath)
+
+		if !hasTF || inSkipDir {
+			startFrom := absPath
+			if hasTF && inSkipDir {
+				// Directory has .tf files but is inside a skip dir — start
+				// from parent so findParentModule doesn't return this dir.
+				startFrom = filepath.Dir(absPath)
+			}
+			absPath = findParentModule(startFrom, basePath)
 			if absPath == "" {
 				continue
 			}
@@ -178,10 +188,11 @@ func resolveChangedModules(basePath, repoRoot string, changedPaths []string) []M
 }
 
 // findParentModule walks up the directory tree to find a parent that contains .tf files
+// and is not inside a skipDir.
 func findParentModule(startPath, stopPath string) string {
 	current := startPath
 	for {
-		if finder.HasTerraformFiles(current) {
+		if finder.HasTerraformFiles(current) && !finder.IsSkipDir(filepath.Base(current)) {
 			return current
 		}
 

--- a/internal/cli/changed_runner.go
+++ b/internal/cli/changed_runner.go
@@ -188,7 +188,7 @@ func resolveChangedModules(basePath, repoRoot string, changedPaths []string) []M
 }
 
 // findParentModule walks up the directory tree to find a parent that contains .tf files
-// and is not inside a skipDir.
+// and is not itself a skipDir.
 func findParentModule(startPath, stopPath string) string {
 	current := startPath
 	for {

--- a/internal/cli/changed_runner.go
+++ b/internal/cli/changed_runner.go
@@ -141,9 +141,16 @@ func resolveChangedModules(basePath, repoRoot string, changedPaths []string) []M
 		if !hasTF || inSkipDir {
 			startFrom := absPath
 			if hasTF && inSkipDir {
-				// Directory has .tf files but is inside a skip dir — start
-				// from parent so findParentModule doesn't return this dir.
+				// Directory has .tf files but is inside a skip dir — walk up
+				// until the relative path no longer contains any skipDir segments.
 				startFrom = filepath.Dir(absPath)
+				for {
+					rel, err := filepath.Rel(repoRoot, startFrom)
+					if err != nil || !finder.PathContainsSkipDir(rel) {
+						break
+					}
+					startFrom = filepath.Dir(startFrom)
+				}
 			}
 			absPath = findParentModule(startFrom, basePath)
 			if absPath == "" {

--- a/internal/cli/changed_runner_test.go
+++ b/internal/cli/changed_runner_test.go
@@ -134,7 +134,7 @@ func TestResolveChangedModules(t *testing.T) {
 func TestResolveChangedModules_SkipsDirs(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create a module with examples/ and tests/ subdirectories that contain .tf files
+	// Create a module with examples/ subdirectories that contain .tf files, and a tests/ directory
 	moduleDir := filepath.Join(tmpDir, "components", "azurerm", "storage-account-test")
 	examplesBasic := filepath.Join(moduleDir, "examples", "basic")
 	examplesPrivateLink := filepath.Join(moduleDir, "examples", "private-link")

--- a/internal/cli/changed_runner_test.go
+++ b/internal/cli/changed_runner_test.go
@@ -137,17 +137,18 @@ func TestResolveChangedModules_SkipsDirs(t *testing.T) {
 	// Create a module with examples/ subdirectories that contain .tf files, and a tests/ directory
 	moduleDir := filepath.Join(tmpDir, "components", "azurerm", "storage-account-test")
 	examplesBasic := filepath.Join(moduleDir, "examples", "basic")
+	examplesBasicNested := filepath.Join(moduleDir, "examples", "basic", "nested")
 	examplesPrivateLink := filepath.Join(moduleDir, "examples", "private-link")
 	testsDir := filepath.Join(moduleDir, "tests")
 
-	for _, dir := range []string{moduleDir, examplesBasic, examplesPrivateLink, testsDir} {
+	for _, dir := range []string{moduleDir, examplesBasic, examplesBasicNested, examplesPrivateLink, testsDir} {
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	// All directories have .tf files
-	for _, dir := range []string{moduleDir, examplesBasic, examplesPrivateLink} {
+	for _, dir := range []string{moduleDir, examplesBasic, examplesBasicNested, examplesPrivateLink} {
 		if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte("# terraform"), 0644); err != nil {
 			t.Fatal(err)
 		}
@@ -168,6 +169,11 @@ func TestResolveChangedModules_SkipsDirs(t *testing.T) {
 		{
 			name:         "examples/basic resolves to parent module",
 			changedPaths: []string{"components/azurerm/storage-account-test/examples/basic"},
+			wantNames:    []string{"storage-account-test"},
+		},
+		{
+			name:         "deeper nested path under skip dir resolves to parent module",
+			changedPaths: []string{"components/azurerm/storage-account-test/examples/basic/nested"},
 			wantNames:    []string{"storage-account-test"},
 		},
 		{

--- a/internal/cli/changed_runner_test.go
+++ b/internal/cli/changed_runner_test.go
@@ -130,3 +130,87 @@ func TestResolveChangedModules(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveChangedModules_SkipsDirs(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a module with examples/ and tests/ subdirectories that contain .tf files
+	moduleDir := filepath.Join(tmpDir, "components", "azurerm", "storage-account-test")
+	examplesBasic := filepath.Join(moduleDir, "examples", "basic")
+	examplesPrivateLink := filepath.Join(moduleDir, "examples", "private-link")
+	testsDir := filepath.Join(moduleDir, "tests")
+
+	for _, dir := range []string{moduleDir, examplesBasic, examplesPrivateLink, testsDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// All directories have .tf files
+	for _, dir := range []string{moduleDir, examplesBasic, examplesPrivateLink} {
+		if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte("# terraform"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// tests/ has a go file but no .tf
+	if err := os.WriteFile(filepath.Join(testsDir, "storage_test.go"), []byte("package test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	withConfig(t, &config.Config{Root: "", Binary: "terraform"})
+
+	tests := []struct {
+		name         string
+		changedPaths []string
+		wantNames    []string
+	}{
+		{
+			name:         "examples/basic resolves to parent module",
+			changedPaths: []string{"components/azurerm/storage-account-test/examples/basic"},
+			wantNames:    []string{"storage-account-test"},
+		},
+		{
+			name:         "examples/private-link resolves to parent module",
+			changedPaths: []string{"components/azurerm/storage-account-test/examples/private-link"},
+			wantNames:    []string{"storage-account-test"},
+		},
+		{
+			name:         "tests/ resolves to parent module",
+			changedPaths: []string{"components/azurerm/storage-account-test/tests"},
+			wantNames:    []string{"storage-account-test"},
+		},
+		{
+			name:         "multiple skipDir paths deduplicate to parent",
+			changedPaths: []string{"components/azurerm/storage-account-test/examples/basic", "components/azurerm/storage-account-test/examples/private-link"},
+			wantNames:    []string{"storage-account-test"},
+		},
+		{
+			name:         "parent module itself still resolves directly",
+			changedPaths: []string{"components/azurerm/storage-account-test"},
+			wantNames:    []string{"storage-account-test"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			modules := resolveChangedModules(tmpDir, tmpDir, tt.changedPaths)
+
+			var gotNames []string
+			for _, m := range modules {
+				gotNames = append(gotNames, m.Name)
+			}
+
+			if len(gotNames) != len(tt.wantNames) {
+				t.Errorf("got %d modules %v, want %d %v", len(gotNames), gotNames, len(tt.wantNames), tt.wantNames)
+				return
+			}
+
+			for i, name := range gotNames {
+				if name != tt.wantNames[i] {
+					t.Errorf("module[%d] = %s, want %s", i, name, tt.wantNames[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/finder/finder.go
+++ b/internal/finder/finder.go
@@ -17,6 +17,24 @@ var skipDirs = map[string]bool{
 	".spacelift":   true,
 }
 
+// IsSkipDir reports whether name is a directory that should be skipped during
+// module discovery (e.g. "examples", "tests", "modules").
+func IsSkipDir(name string) bool {
+	return skipDirs[name]
+}
+
+// PathContainsSkipDir reports whether any segment of a filepath matches a
+// skipDirs entry. This is used to detect paths like "modules/foo/examples/basic"
+// that should not be treated as standalone modules.
+func PathContainsSkipDir(path string) bool {
+	for _, segment := range strings.Split(filepath.ToSlash(path), "/") {
+		if skipDirs[segment] {
+			return true
+		}
+	}
+	return false
+}
+
 // FindModule searches for a module with the given name in the specified search path
 // It recursively searches subdirectories and returns all matching directories
 // Only directories containing .tf or .tf.json files are considered valid modules

--- a/internal/finder/finder_test.go
+++ b/internal/finder/finder_test.go
@@ -405,6 +405,55 @@ func TestListAllModules_SkipsTerraformDir(t *testing.T) {
 	}
 }
 
+func TestIsSkipDir(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"examples", true},
+		{"tests", true},
+		{"modules", true},
+		{".terraform", true},
+		{".git", true},
+		{"node_modules", true},
+		{".spacelift", true},
+		{"components", false},
+		{"azurerm", false},
+		{"src", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSkipDir(tt.name); got != tt.want {
+				t.Errorf("IsSkipDir(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPathContainsSkipDir(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"components/azurerm/storage-account/examples/basic", true},
+		{"components/azurerm/storage-account/tests", true},
+		{"components/azurerm/storage-account/modules/internal", true},
+		{"components/azurerm/storage-account", false},
+		{"projects/prod-infra", false},
+		{"examples/basic", true},
+		{"tests", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := PathContainsSkipDir(tt.path); got != tt.want {
+				t.Errorf("PathContainsSkipDir(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFindModule_SkipsGitDir(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -152,8 +152,10 @@ func (r *Runner) RunTestWithOutput(dir string, stdout, stderr io.Writer, extraAr
 		cmd.Stderr = io.MultiWriter(stderr, &stderrBuf)
 
 		if err := cmd.Run(); err != nil {
-			if strings.Contains(stderrBuf.String(), "matched no packages") {
-				return nil
+			if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+				if strings.Contains(stderrBuf.String(), "matched no packages") {
+					return nil
+				}
 			}
 			return err
 		}

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -143,7 +144,22 @@ func (r *Runner) RunTestWithOutput(dir string, stdout, stderr io.Writer, extraAr
 
 	cmd.Dir = dir
 	cmd.Stdout = stdout
-	cmd.Stderr = stderr
 
-	return cmd.Run()
+	switch r.config.Test.Engine {
+	case "terratest":
+		// Capture stderr to detect "matched no packages" from go test ./...
+		var stderrBuf bytes.Buffer
+		cmd.Stderr = io.MultiWriter(stderr, &stderrBuf)
+
+		if err := cmd.Run(); err != nil {
+			if strings.Contains(stderrBuf.String(), "matched no packages") {
+				return nil
+			}
+			return err
+		}
+		return nil
+	default:
+		cmd.Stderr = stderr
+		return cmd.Run()
+	}
 }


### PR DESCRIPTION
This pull request improves how the CLI detects and resolves changed Terraform modules, especially when changes occur within example or test directories that should not be treated as standalone modules. It introduces utility functions for identifying "skip" directories, updates the resolution logic, and adds comprehensive tests to ensure correct behavior.

**Module resolution logic improvements:**

* Updated `resolveChangedModules` to ensure that changes within skip directories (like `examples/`, `tests/`, etc.) are resolved to their parent module, even if those directories contain `.tf` files. This prevents subdirectories meant for examples or tests from being incorrectly treated as standalone modules.
* Modified `findParentModule` to skip directories that are themselves skipDirs when walking up the tree to find the parent module.

**New utility functions for skip directories:**

* Added `IsSkipDir` and `PathContainsSkipDir` to `internal/finder/finder.go` to identify skip directories and to check if any segment of a path is a skip directory.

**Testing improvements:**

* Added `TestResolveChangedModules_SkipsDirs` to verify that changes in skip directories correctly resolve to their parent modules and are deduplicated.
* Added tests for the new skip directory utility functions: `TestIsSkipDir` and `TestPathContainsSkipDir`.

**Terraform runner fix:**

* Updated `RunTestWithOutput` to capture and inspect `stderr` output when using the "terratest" engine, suppressing errors when "matched no packages" is detected, which can occur when running `go test ./...` in directories without Go packages. [[1]](diffhunk://#diff-130384c6683ec252f0b6306b465d7e6f6dfb4d1b6494f602b9d81aea89c554e1L146-R165) [[2]](diffhunk://#diff-130384c6683ec252f0b6306b465d7e6f6dfb4d1b6494f602b9d81aea89c554e1R4)