### PR TITLE
Add scope variable and --changed to get and describe cmds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ go.work
 
 # Build artifacts
 /motf
+demo/motf
 dist/
 build/
 

--- a/demo/.motf.yml
+++ b/demo/.motf.yml
@@ -30,3 +30,9 @@ tasks:
     description: "ls on the root path"
     shell: bash
     command: "ls -la '$MOTF_GIT_ROOT'"
+
+  cat-config:
+    description: "Cat the .motf.yml file"
+    scope: root
+    shell: bash
+    command: "cat .motf.yml"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -344,9 +344,13 @@ motf get <module-name> [flags]
 
 ### Flags
 
-| Flag | Description |
-|------|-------------|
-| `--json` | Output in JSON format |
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--json` | | Output in JSON format |
+| `--changed` | | Run on all modules changed compared to `--ref` |
+| `--ref` | | Git ref to compare against (default: auto-detect from `origin/HEAD`) |
+| `--parallel` | `-p` | Run commands in parallel across modules |
+| `--max-parallel` | | Maximum parallel jobs (default: number of CPU cores) |
 
 ### Examples
 
@@ -359,6 +363,15 @@ motf get --path ./my-module
 
 # Output as JSON
 motf get storage-account --json
+
+# Get details for all changed modules
+motf get --changed
+
+# Get changed modules as JSON array
+motf get --changed --json
+
+# Get changed modules in parallel
+motf get --changed --parallel
 ```
 
 ### Output
@@ -391,9 +404,13 @@ motf describe <module-name> [flags]
 
 ### Flags
 
-| Flag | Description |
-|------|-------------|
-| `--json` | Output in JSON format |
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--json` | | Output in JSON format |
+| `--changed` | | Run on all modules changed compared to `--ref` |
+| `--ref` | | Git ref to compare against (default: auto-detect from `origin/HEAD`) |
+| `--parallel` | `-p` | Run commands in parallel across modules |
+| `--max-parallel` | | Maximum parallel jobs (default: number of CPU cores) |
 
 ### Examples
 
@@ -406,6 +423,15 @@ motf describe --path ./my-module
 
 # Output as JSON
 motf describe storage-account --json
+
+# Describe all changed modules
+motf describe --changed
+
+# Describe changed modules as JSON array
+motf describe --changed --json
+
+# Describe changed modules in parallel
+motf describe --changed --parallel
 ```
 
 ### Output

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -464,13 +464,30 @@ See [Configuration](configuration#custom-tasks) for how to define tasks.
 | `--parallel` | `-p` | Run commands in parallel across modules |
 | `--max-parallel` | | Maximum parallel jobs (default: number of CPU cores) |
 
+### Task Scope
+
+Tasks with `scope: root` or `scope: git` run once from the configured root or git repository root respectively. They do not require a module name and ignore `--changed`:
+
+```bash
+# Run a root-scoped task (no module name needed)
+motf task -t fmt-all
+
+# Run a git-scoped task
+motf task -t pre-commit
+
+# --changed is ignored for scoped tasks
+motf task -t fmt-all --changed
+```
+
+Tasks with `scope: module` (the default) behave as normal per-module tasks.
+
 ### Examples
 
 ```bash
 # List available tasks
 motf task --list
 
-# Run a specific task
+# Run a specific task on a module
 motf task storage-account --task lint
 
 # Run a task on an example
@@ -484,6 +501,9 @@ motf task --changed --task lint
 
 # Run task on changed modules in parallel
 motf task --changed --task lint --parallel
+
+# Run a root/git scoped task (no module needed)
+motf task -t fmt-all
 ```
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,11 @@ tasks:
     description: "Run tflint on the module"
     command: "tflint --init && tflint"
 
+  fmt-all:
+    description: "Format all terraform files"
+    scope: root
+    command: "terraform fmt -recursive"
+
   docs:
     description: "Generate terraform-docs"
     shell: bash
@@ -205,6 +210,51 @@ tasks:
 | `command` | Yes | - | Shell command(s) to execute |
 | `description` | No | `""` | Description shown when listing tasks |
 | `shell` | No | `"sh"` | Shell to use for execution |
+| `scope` | No | `"module"` | Where the task runs: `module`, `root`, or `git` |
+
+### Task Scope
+
+The `scope` field controls where and how a task is executed:
+
+| Scope | Runs From | Behavior |
+|-------|-----------|----------|
+| `module` | Module directory | Default. Runs per-module, respects `--changed`, `--example`, and module name args |
+| `root` | Configured `root` path | Runs once from the path set by the `root` config option |
+| `git` | Git repository root | Runs once from the git repo root |
+
+Tasks with `scope: root` or `scope: git` ignore `--changed` and module discovery. They cannot be combined with `--example` or a positional module name.
+
+```yaml
+tasks:
+  # Runs per-module (default)
+  lint:
+    description: "Lint a single module"
+    command: "tflint --init && tflint"
+
+  # Runs once from the configured root (where modules live)
+  fmt-all:
+    description: "Format all terraform files"
+    command: "terraform fmt -recursive"
+    scope: root
+
+  # Runs once from the git repo root
+  pre-commit:
+    description: "Run pre-commit checks"
+    scope: git
+    shell: bash
+    command: |
+      set -e
+      pre-commit run --all-files
+```
+
+When listing tasks, non-module scopes are shown with an indicator:
+
+```
+Available tasks:
+  fmt-all [root]       Format all terraform files
+  lint                 Lint a single module
+  pre-commit [git]     Run pre-commit checks
+```
 
 ### Supported Shells
 
@@ -267,8 +317,8 @@ MOTF injects the following environment variables into every task execution:
 | Variable | Description |
 |----------|-------------|
 | `MOTF_GIT_ROOT` | Absolute path to the git repository root (empty if not in a git repo) |
-| `MOTF_MODULE_PATH` | Absolute path to the current module being processed |
-| `MOTF_MODULE_NAME` | Name of the module (last component of the path, e.g., `storage-account`) |
+| `MOTF_MODULE_PATH` | Absolute path to the current module being processed (empty for `root`/`git` scoped tasks) |
+| `MOTF_MODULE_NAME` | Name of the module (last component of the path, e.g., `storage-account`; empty for `root`/`git` scoped tasks) |
 | `MOTF_CONFIG_PATH` | Absolute path to the `.motf.yml` config file (empty if no config) |
 | `MOTF_BINARY` | The terraform/tofu binary name (`terraform` or `tofu`) |
 
@@ -299,6 +349,15 @@ tasks:
 tasks:
   pre-commit:
     description: "Run all pre-commit checks"
+    scope: git
+    shell: bash
+    command: |
+      set -e
+      terraform fmt -check -recursive
+      tflint --init && tflint --recursive
+
+  lint-module:
+    description: "Lint a single module"
     shell: bash
     command: |
       set -e

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1242,3 +1242,221 @@ func TestE2E_ParallelFlag_MaxParallel(t *testing.T) {
 		}
 	}
 }
+
+// TestE2E_TaskScope_Git tests that a git-scoped task runs from the git root
+func TestE2E_TaskScope_Git(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	configContent := `binary: terraform
+tasks:
+  fmt-all:
+    description: "Format all"
+    command: echo "ran from $(pwd)"
+    scope: git
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".motf.yml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cmd := exec.Command(motfBinary, "task", "-t", "fmt-all")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("motf task -t fmt-all failed: %v\nOutput: %s", err, output)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "ran from "+tmpDir) {
+		t.Errorf("expected task to run from git root %s, got: %s", tmpDir, outputStr)
+	}
+}
+
+// TestE2E_TaskScope_Root tests that a root-scoped task runs from the configured root
+func TestE2E_TaskScope_Root(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	// Set root to a subdirectory (different from git root)
+	configContent := `binary: terraform
+root: components
+tasks:
+  check:
+    description: "Check from root"
+    command: echo "ran from $(pwd)"
+    scope: root
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".motf.yml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cmd := exec.Command(motfBinary, "task", "-t", "check")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("motf task -t check failed: %v\nOutput: %s", err, output)
+	}
+
+	outputStr := string(output)
+	expectedDir := filepath.Join(tmpDir, "components")
+	if !strings.Contains(outputStr, "ran from "+expectedDir) {
+		t.Errorf("expected task to run from root %s, got: %s", expectedDir, outputStr)
+	}
+}
+
+// TestE2E_TaskScope_IgnoresChanged tests that a scoped task ignores --changed
+func TestE2E_TaskScope_IgnoresChanged(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	configContent := `binary: terraform
+tasks:
+  check:
+    description: "Git check"
+    command: echo "scoped-check-ran"
+    scope: git
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".motf.yml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cmd := exec.Command(motfBinary, "task", "-t", "check", "--changed")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("motf task -t check --changed failed: %v\nOutput: %s", err, output)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "scoped-check-ran") {
+		t.Errorf("expected 'scoped-check-ran' in output, got: %s", outputStr)
+	}
+}
+
+// TestE2E_TaskScope_RejectsExample tests that --example is rejected for scoped tasks
+func TestE2E_TaskScope_RejectsExample(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	configContent := `binary: terraform
+tasks:
+  fmt-all:
+    command: echo hello
+    scope: git
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".motf.yml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cmd := exec.Command(motfBinary, "task", "-t", "fmt-all", "-e", "basic")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error when using --example with scoped task, output: %s", output)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "cannot use --example or module name with git-scoped task") {
+		t.Errorf("expected error message about scope incompatibility, got: %s", outputStr)
+	}
+}
+
+// TestE2E_TaskScope_RejectsModuleName tests that positional module name is rejected for scoped tasks
+func TestE2E_TaskScope_RejectsModuleName(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	configContent := `binary: terraform
+tasks:
+  fmt-all:
+    command: echo hello
+    scope: root
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".motf.yml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cmd := exec.Command(motfBinary, "task", "some-module", "-t", "fmt-all")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error when using module name with scoped task, output: %s", output)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "cannot use --example or module name with root-scoped task") {
+		t.Errorf("expected error message about scope incompatibility, got: %s", outputStr)
+	}
+}
+
+// TestE2E_TaskScope_ListShowsScopeIndicator tests that --list shows scope for non-module tasks
+func TestE2E_TaskScope_ListShowsScopeIndicator(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := t.TempDir()
+
+	createModules(t, tmpDir, []string{"test-component"})
+
+	configContent := `binary: terraform
+tasks:
+  fmt-all:
+    description: "Format everything"
+    command: "terraform fmt -recursive"
+    scope: git
+  check:
+    description: "Check from root"
+    command: "echo check"
+    scope: root
+  lint:
+    description: "Lint module"
+    command: "tflint"
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".motf.yml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cmd := exec.Command(motfBinary, "task", "test-component", "--list")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("motf task --list failed: %v\nOutput: %s", err, output)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "fmt-all [git]") {
+		t.Errorf("expected 'fmt-all [git]' in list output, got: %s", outputStr)
+	}
+	if !strings.Contains(outputStr, "check [root]") {
+		t.Errorf("expected 'check [root]' in list output, got: %s", outputStr)
+	}
+	if strings.Contains(outputStr, "lint [") {
+		t.Errorf("expected 'lint' without scope indicator in list output, got: %s", outputStr)
+	}
+}
+
+// TestE2E_TaskScope_InvalidScope tests that an invalid scope produces an error
+func TestE2E_TaskScope_InvalidScope(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	configContent := `binary: terraform
+tasks:
+  bad:
+    command: echo hello
+    scope: invalid
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".motf.yml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cmd := exec.Command(motfBinary, "task", "-t", "bad")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error for invalid scope, output: %s", output)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "unknown scope") {
+		t.Errorf("expected 'unknown scope' in error, got: %s", outputStr)
+	}
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1460,3 +1460,183 @@ tasks:
 		t.Errorf("expected 'unknown scope' in error, got: %s", outputStr)
 	}
 }
+
+func TestE2E_DescribeChanged(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	cmd := exec.Command(motfBinary, "describe", "--changed", "--ref", "HEAD")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("motf describe --changed failed: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(string(output), "No changed modules found") {
+		t.Errorf("expected 'No changed modules found' in clean repo, got: %s", output)
+	}
+}
+
+func TestE2E_DescribeChanged_DetectsModule(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	addUncommittedFile(t, tmpDir, []string{"test-module"}, "variables.tf", "variable \"%s\" { type = string }\n")
+
+	cmd := exec.Command(motfBinary, "describe", "--changed", "--ref", "HEAD")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("motf describe --changed failed: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(string(output), "test-module") {
+		t.Errorf("expected test-module in output, got: %s", output)
+	}
+}
+
+func TestE2E_DescribeChanged_JSON(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	cmd := exec.Command(motfBinary, "describe", "--changed", "--ref", "HEAD", "--json")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("motf describe --changed --json failed: %v\nOutput: %s", err, output)
+	}
+
+	var result []interface{}
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("describe --changed --json output is not valid JSON: %v\nOutput: %s", err, output)
+	}
+
+	if len(result) != 0 {
+		t.Errorf("expected empty array in clean repo, got: %v", result)
+	}
+}
+
+func TestE2E_DescribeChanged_JSON_DetectsModule(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	addUncommittedFile(t, tmpDir, []string{"test-module"}, "variables.tf", "variable \"%s\" { type = string }\n")
+
+	cmd := exec.Command(motfBinary, "describe", "--changed", "--ref", "HEAD", "--json")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("motf describe --changed --json failed: %v\nOutput: %s", err, output)
+	}
+
+	var result []interface{}
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nOutput: %s", err, output)
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(result))
+	}
+}
+
+func TestE2E_GetChanged(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	cmd := exec.Command(motfBinary, "get", "--changed", "--ref", "HEAD")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("motf get --changed failed: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(string(output), "No changed modules found") {
+		t.Errorf("expected 'No changed modules found' in clean repo, got: %s", output)
+	}
+}
+
+func TestE2E_GetChanged_DetectsModule(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	addUncommittedFile(t, tmpDir, []string{"test-module"}, "outputs.tf", "output \"%s\" { value = \"x\" }\n")
+
+	cmd := exec.Command(motfBinary, "get", "--changed", "--ref", "HEAD")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("motf get --changed failed: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(string(output), "test-module") {
+		t.Errorf("expected test-module in output, got: %s", output)
+	}
+}
+
+func TestE2E_GetChanged_JSON(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	cmd := exec.Command(motfBinary, "get", "--changed", "--ref", "HEAD", "--json")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("motf get --changed --json failed: %v\nOutput: %s", err, output)
+	}
+
+	var result []interface{}
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("get --changed --json output is not valid JSON: %v\nOutput: %s", err, output)
+	}
+
+	if len(result) != 0 {
+		t.Errorf("expected empty array in clean repo, got: %v", result)
+	}
+}
+
+func TestE2E_GetChanged_JSON_DetectsModule(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	addUncommittedFile(t, tmpDir, []string{"test-module"}, "outputs.tf", "output \"%s\" { value = \"x\" }\n")
+
+	cmd := exec.Command(motfBinary, "get", "--changed", "--ref", "HEAD", "--json")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("motf get --changed --json failed: %v\nOutput: %s", err, output)
+	}
+
+	var result []interface{}
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nOutput: %s", err, output)
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(result))
+	}
+}
+
+func TestE2E_DescribeChanged_RejectsModuleArg(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	cmd := exec.Command(motfBinary, "describe", "--changed", "--ref", "HEAD", "test-module")
+	cmd.Dir = tmpDir
+	_, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected error when combining --changed with module arg")
+	}
+}
+
+func TestE2E_GetChanged_RejectsModuleArg(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	cmd := exec.Command(motfBinary, "get", "--changed", "--ref", "HEAD", "test-module")
+	cmd.Dir = tmpDir
+	_, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected error when combining --changed with module arg")
+	}
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1389,6 +1389,34 @@ tasks:
 	}
 }
 
+// TestE2E_TaskScope_RejectsPath tests that --path is rejected for scoped tasks
+func TestE2E_TaskScope_RejectsPath(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	configContent := `binary: terraform
+tasks:
+  fmt-all:
+    command: echo hello
+    scope: git
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".motf.yml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cmd := exec.Command(motfBinary, "task", "--path", "./some/path", "-t", "fmt-all")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error when using --path with scoped task, output: %s", output)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "cannot use --path with git-scoped task") {
+		t.Errorf("expected error message about --path incompatibility, got: %s", outputStr)
+	}
+}
+
 // TestE2E_TaskScope_ListShowsScopeIndicator tests that --list shows scope for non-module tasks
 func TestE2E_TaskScope_ListShowsScopeIndicator(t *testing.T) {
 	motfBinary := buildMotf(t)

--- a/internal/cli/changed_flags_test.go
+++ b/internal/cli/changed_flags_test.go
@@ -46,3 +46,21 @@ func TestTestCmd_HasChangedFlags(t *testing.T) {
 		t.Fatal("testCmd should have --ref flag")
 	}
 }
+
+func TestDescribeCmd_HasChangedFlags(t *testing.T) {
+	if describeCmd.Flags().Lookup("changed") == nil {
+		t.Fatal("describeCmd should have --changed flag")
+	}
+	if describeCmd.Flags().Lookup("ref") == nil {
+		t.Fatal("describeCmd should have --ref flag")
+	}
+}
+
+func TestGetCmd_HasChangedFlags(t *testing.T) {
+	if getCmd.Flags().Lookup("changed") == nil {
+		t.Fatal("getCmd should have --changed flag")
+	}
+	if getCmd.Flags().Lookup("ref") == nil {
+		t.Fatal("getCmd should have --ref flag")
+	}
+}

--- a/internal/cli/describe.go
+++ b/internal/cli/describe.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"path/filepath"
 	"strings"
 
 	"github.com/TechnicallyJoe/terraform-motf/internal/terraform"
@@ -27,10 +29,32 @@ input variables (with types, defaults, and descriptions), and outputs.`,
 
 func init() {
 	describeCmd.Flags().BoolVar(&describeJsonFlag, "json", false, "Output in JSON format")
+	describeCmd.Flags().BoolVar(&changedFlag, "changed", false, "Run on modules changed compared to --ref")
+	describeCmd.Flags().StringVar(&refFlag, "ref", "", "Git ref for --changed (default: auto-detect from origin/HEAD)")
+	describeCmd.Flags().BoolVarP(&parallelFlag, "parallel", "p", false, "Run commands in parallel")
+	describeCmd.Flags().IntVar(&maxParallelFlag, "max-parallel", 0, "Maximum parallel jobs (default: number of CPU cores)")
 	rootCmd.AddCommand(describeCmd)
 }
 
 func runDescribe(cmd *cobra.Command, args []string) error {
+	if changedFlag {
+		if len(args) > 0 {
+			return cobra.MaximumNArgs(0)(cmd, args)
+		}
+		if describeJsonFlag {
+			return describeChangedJSON()
+		}
+		return runOnChangedModulesWithPath(func(moduleAbsPath string, stdout, stderr io.Writer) error {
+			schema, err := terraform.LoadModuleSchema(moduleAbsPath, getRoot())
+			if err != nil {
+				_, _ = fmt.Fprintf(stderr, "failed to parse module: %v\n", err)
+				return err
+			}
+			printSchemaToWriter(stdout, schema)
+			return nil
+		})
+	}
+
 	targetPath, err := resolveTargetPath(args)
 	if err != nil {
 		return err
@@ -49,6 +73,35 @@ func runDescribe(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func describeChangedJSON() error {
+	modules, err := detectChangedModules(refFlag)
+	if err != nil {
+		return err
+	}
+
+	basePath, err := getBasePath()
+	if err != nil {
+		return err
+	}
+
+	schemas := make([]*terraform.ModuleSchema, 0)
+	for _, mod := range modules {
+		absPath := filepath.Join(basePath, mod.Path)
+		schema, err := terraform.LoadModuleSchema(absPath, getRoot())
+		if err != nil {
+			continue
+		}
+		schemas = append(schemas, schema)
+	}
+
+	output, err := json.MarshalIndent(schemas, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+	fmt.Println(string(output))
+	return nil
+}
+
 func printSchemaJSON(cmd *cobra.Command, schema *terraform.ModuleSchema) error {
 	output, err := json.MarshalIndent(schema, "", "  ")
 	if err != nil {
@@ -56,6 +109,69 @@ func printSchemaJSON(cmd *cobra.Command, schema *terraform.ModuleSchema) error {
 	}
 	cmd.Println(string(output))
 	return nil
+}
+
+func printSchemaToWriter(w io.Writer, schema *terraform.ModuleSchema) {
+	_, _ = fmt.Fprintf(w, "Module: %s\n", schema.Name)
+	_, _ = fmt.Fprintf(w, "Path:   %s\n", schema.Path)
+
+	if schema.TerraformVersion != "" {
+		_, _ = fmt.Fprintf(w, "\nTerraform: %s\n", schema.TerraformVersion)
+	}
+
+	if len(schema.Providers) > 0 {
+		_, _ = fmt.Fprintln(w, "\nProviders:")
+		_, _ = fmt.Fprintf(w, "  %-20s %s\n", "NAME", "VERSION")
+		for _, p := range schema.Providers {
+			version := p.Version
+			if version == "" {
+				version = "(any)"
+			}
+			_, _ = fmt.Fprintf(w, "  %-20s %s\n", p.Name, version)
+		}
+	}
+
+	if len(schema.Variables) > 0 {
+		_, _ = fmt.Fprintln(w, "\nVariables:")
+		_, _ = fmt.Fprintf(w, "  %-25s %-15s %-15s %s\n", "NAME", "TYPE", "DEFAULT", "DESCRIPTION")
+		for _, v := range schema.Variables {
+			typeStr := normalizeType(v.Type)
+			defaultStr := v.DefaultString()
+			descLines := wrapText(v.Description, 60)
+			firstDesc := ""
+			if len(descLines) > 0 {
+				firstDesc = descLines[0]
+			}
+			_, _ = fmt.Fprintf(w, "  %-25s %-15s %-15s %s\n", truncate(v.Name, 25), truncate(typeStr, 15), truncate(defaultStr, 15), firstDesc)
+			for i := 1; i < len(descLines); i++ {
+				_, _ = fmt.Fprintf(w, "  %-25s %-15s %-15s %s\n", "", "", "", descLines[i])
+			}
+		}
+	}
+
+	if len(schema.Outputs) > 0 {
+		_, _ = fmt.Fprintln(w, "\nOutputs:")
+		_, _ = fmt.Fprintf(w, "  %-25s %s\n", "NAME", "DESCRIPTION")
+		for _, o := range schema.Outputs {
+			desc := o.Description
+			if o.Sensitive {
+				if desc != "" {
+					desc += " (sensitive)"
+				} else {
+					desc = "(sensitive)"
+				}
+			}
+			descLines := wrapText(desc, 60)
+			firstDesc := ""
+			if len(descLines) > 0 {
+				firstDesc = descLines[0]
+			}
+			_, _ = fmt.Fprintf(w, "  %-25s %s\n", truncate(o.Name, 25), firstDesc)
+			for i := 1; i < len(descLines); i++ {
+				_, _ = fmt.Fprintf(w, "  %-25s %s\n", "", descLines[i])
+			}
+		}
+	}
 }
 
 func printSchema(cmd *cobra.Command, schema *terraform.ModuleSchema) {

--- a/internal/cli/describe.go
+++ b/internal/cli/describe.go
@@ -89,7 +89,7 @@ func describeChangedJSON() error {
 		absPath := filepath.Join(basePath, mod.Path)
 		schema, err := terraform.LoadModuleSchema(absPath, getRoot())
 		if err != nil {
-			continue
+			return fmt.Errorf("failed to parse module %s: %w", mod.Path, err)
 		}
 		schemas = append(schemas, schema)
 	}
@@ -118,6 +118,8 @@ func printSchemaToWriter(w io.Writer, schema *terraform.ModuleSchema) {
 	if schema.TerraformVersion != "" {
 		_, _ = fmt.Fprintf(w, "\nTerraform: %s\n", schema.TerraformVersion)
 	}
+
+	printExampleToWriter(w, schema)
 
 	if len(schema.Providers) > 0 {
 		_, _ = fmt.Fprintln(w, "\nProviders:")
@@ -273,6 +275,30 @@ func printExample(cmd *cobra.Command, schema *terraform.ModuleSchema) {
 	}
 
 	cmd.Println("  }")
+}
+
+func printExampleToWriter(w io.Writer, schema *terraform.ModuleSchema) {
+	_, _ = fmt.Fprintln(w, "\nExample:")
+	_, _ = fmt.Fprintf(w, "  module \"%s\" {\n", schema.Name)
+	_, _ = fmt.Fprintf(w, "    source = \"%s\"\n", schema.Path)
+
+	maxLen := 0
+	for _, v := range schema.Variables {
+		if v.Required && len(v.Name) > maxLen {
+			maxLen = len(v.Name)
+		}
+	}
+
+	if maxLen > 0 {
+		_, _ = fmt.Fprintln(w)
+		for _, v := range schema.Variables {
+			if v.Required {
+				_, _ = fmt.Fprintf(w, "    %-*s = %s\n", maxLen, v.Name, v.EmptyValueForType())
+			}
+		}
+	}
+
+	_, _ = fmt.Fprintln(w, "  }")
 }
 
 // normalizeType simplifies complex type definitions for display in tables.

--- a/internal/cli/fmt.go
+++ b/internal/cli/fmt.go
@@ -18,7 +18,8 @@ Examples:
   motf fmt storage-account              # Run fmt on storage-account module
   motf fmt storage-account -e basic     # Run fmt on the 'basic' example
   motf fmt -i storage-account -e basic  # Run init then fmt on the 'basic' example`,
-	Args: cobra.MaximumNArgs(1),
+	Args:     cobra.MaximumNArgs(1),
+	PreRunE:  requiresBinary,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if changedFlag {
 			if len(args) > 0 {

--- a/internal/cli/fmt.go
+++ b/internal/cli/fmt.go
@@ -18,8 +18,8 @@ Examples:
   motf fmt storage-account              # Run fmt on storage-account module
   motf fmt storage-account -e basic     # Run fmt on the 'basic' example
   motf fmt -i storage-account -e basic  # Run init then fmt on the 'basic' example`,
-	Args:     cobra.MaximumNArgs(1),
-	PreRunE:  requiresBinary,
+	Args:    cobra.MaximumNArgs(1),
+	PreRunE: requiresBinary,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if changedFlag {
 			if len(args) > 0 {

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,6 +35,10 @@ Examples:
 
 func init() {
 	getCmd.Flags().BoolVar(&getJsonFlag, "json", false, "Output in JSON format")
+	getCmd.Flags().BoolVar(&changedFlag, "changed", false, "Run on modules changed compared to --ref")
+	getCmd.Flags().StringVar(&refFlag, "ref", "", "Git ref for --changed (default: auto-detect from origin/HEAD)")
+	getCmd.Flags().BoolVarP(&parallelFlag, "parallel", "p", false, "Run commands in parallel")
+	getCmd.Flags().IntVar(&maxParallelFlag, "max-parallel", 0, "Maximum parallel jobs (default: number of CPU cores)")
 	rootCmd.AddCommand(getCmd)
 }
 
@@ -58,6 +63,24 @@ type ItemInfo struct {
 }
 
 func runGet(cmd *cobra.Command, args []string) error {
+	if changedFlag {
+		if len(args) > 0 {
+			return cobra.MaximumNArgs(0)(cmd, args)
+		}
+		if getJsonFlag {
+			return getChangedJSON()
+		}
+		return runOnChangedModulesWithPath(func(moduleAbsPath string, stdout, stderr io.Writer) error {
+			details, err := getModuleDetails(moduleAbsPath)
+			if err != nil {
+				_, _ = fmt.Fprintf(stderr, "failed to get module details: %v\n", err)
+				return err
+			}
+			printModuleDetailsToWriter(stdout, details)
+			return nil
+		})
+	}
+
 	targetPath, err := resolveTargetPath(args)
 	if err != nil {
 		return err
@@ -73,6 +96,35 @@ func runGet(cmd *cobra.Command, args []string) error {
 	}
 
 	printModuleDetails(details)
+	return nil
+}
+
+func getChangedJSON() error {
+	modules, err := detectChangedModules(refFlag)
+	if err != nil {
+		return err
+	}
+
+	basePath, err := getBasePath()
+	if err != nil {
+		return err
+	}
+
+	results := make([]*ModuleDetails, 0)
+	for _, mod := range modules {
+		absPath := filepath.Join(basePath, mod.Path)
+		details, err := getModuleDetails(absPath)
+		if err != nil {
+			continue
+		}
+		results = append(results, details)
+	}
+
+	output, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+	fmt.Println(string(output))
 	return nil
 }
 
@@ -195,6 +247,37 @@ func listTestFiles(path, basePath string) []ItemInfo {
 	}
 
 	return items
+}
+
+func printModuleDetailsToWriter(w io.Writer, details *ModuleDetails) {
+	_, _ = fmt.Fprintf(w, "Name:                  %s\n", details.Name)
+	_, _ = fmt.Fprintf(w, "Type:                  %s\n", formatType(details.Type))
+	_, _ = fmt.Fprintf(w, "Path:                  %s\n", details.Path)
+	_, _ = fmt.Fprintf(w, "Spacelift Version:     %s\n", details.SpaceliftVersion)
+	_, _ = fmt.Fprintf(w, "Has Submodules:        %s\n", formatBool(details.HasSubmodules))
+	_, _ = fmt.Fprintf(w, "Has Tests:             %s\n", formatBool(details.HasTests))
+	_, _ = fmt.Fprintf(w, "Has Examples:          %s\n", formatBool(details.HasExamples))
+
+	if len(details.Submodules) > 0 {
+		_, _ = fmt.Fprintln(w, "\nSubmodules:")
+		for _, ex := range details.Submodules {
+			_, _ = fmt.Fprintf(w, "  - %s (%s)\n", ex.Name, ex.Path)
+		}
+	}
+
+	if len(details.Examples) > 0 {
+		_, _ = fmt.Fprintln(w, "\nExamples:")
+		for _, ex := range details.Examples {
+			_, _ = fmt.Fprintf(w, "  - %s (%s)\n", ex.Name, ex.Path)
+		}
+	}
+
+	if len(details.Tests) > 0 {
+		_, _ = fmt.Fprintln(w, "\nTests:")
+		for _, ex := range details.Tests {
+			_, _ = fmt.Fprintf(w, "  - %s (%s)\n", ex.Name, ex.Path)
+		}
+	}
 }
 
 // printModuleDetails outputs the module details in a formatted way

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -115,7 +115,7 @@ func getChangedJSON() error {
 		absPath := filepath.Join(basePath, mod.Path)
 		details, err := getModuleDetails(absPath)
 		if err != nil {
-			continue
+			return fmt.Errorf("failed to get details for %s: %w", mod.Path, err)
 		}
 		results = append(results, details)
 	}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -17,7 +17,8 @@ Use the --example/-e flag to run init on a specific example instead of the modul
 Examples:
   motf init storage-account              # Run init on storage-account module
   motf init storage-account -e basic     # Run init on the 'basic' example`,
-	Args: cobra.MaximumNArgs(1),
+	Args:    cobra.MaximumNArgs(1),
+	PreRunE: requiresBinary,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if changedFlag {
 			if len(args) > 0 {

--- a/internal/cli/plan.go
+++ b/internal/cli/plan.go
@@ -19,7 +19,8 @@ Examples:
   motf plan storage-account -e basic        # Run plan on the 'basic' example
   motf plan storage-account --example basic # Run plan on the 'basic' example
   motf plan -i storage-account              # Run init then plan`,
-	Args: cobra.MaximumNArgs(1),
+	Args:    cobra.MaximumNArgs(1),
+	PreRunE: requiresBinary,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if changedFlag {
 			if len(args) > 0 {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -101,3 +101,12 @@ func init() {
 func Execute() error {
 	return rootCmd.Execute()
 }
+
+// requiresBinary is a PreRunE hook for commands that need the terraform/tofu binary
+func requiresBinary(cmd *cobra.Command, args []string) error {
+	if err := runner.CheckBinary(); err != nil {
+		cmd.SilenceUsage = true
+		return err
+	}
+	return nil
+}

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -23,6 +23,11 @@ var taskCmd = &cobra.Command{
 Tasks are shell commands configured in your .motf.yml file under the 'tasks' section.
 By default, or with --list, shows all available tasks.
 
+Tasks support a 'scope' field to control where they run:
+  scope: module  (default) Run per-module as normal
+  scope: root    Run once from the configured root path
+  scope: git     Run once from the git repository root
+
 Examples:
   motf task storage-account                    # List available tasks
   motf task storage-account --list             # List available tasks
@@ -31,7 +36,8 @@ Examples:
   motf task storage-account -t lint -e basic   # Run 'lint' task on 'basic' example
   motf task --path ./modules/x -t docs         # Run task on explicit path
   motf task -t lint --changed                  # Run 'lint' task on changed modules
-  motf task -t lint --changed --parallel       # Run 'lint' task on changed modules in parallel`,
+  motf task -t lint --changed --parallel       # Run 'lint' task on changed modules in parallel
+  motf task -t fmt                             # Run scoped task (scope: root or git)`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// If no task specified, list tasks
@@ -41,6 +47,40 @@ Examples:
 
 		// Get git root (soft fail - empty string if not in git repo)
 		gitRoot, _ := git.GetRepoRoot()
+
+		// Non-module scoped tasks run once from a specific directory
+		if taskCfg := cfg.Tasks[taskFlag]; taskCfg != nil {
+			if err := taskCfg.ValidateScope(); err != nil {
+				return fmt.Errorf("task %q: %w", taskFlag, err)
+			}
+
+			scope := taskCfg.EffectiveScope()
+			if scope != tasks.ScopeModule {
+				if exampleFlag != "" || len(args) > 0 {
+					return fmt.Errorf("cannot use --example or module name with %s-scoped task %q", scope, taskFlag)
+				}
+
+				var workDir string
+				switch scope {
+				case tasks.ScopeGit:
+					workDir = gitRoot
+				case tasks.ScopeRoot:
+					basePath, err := getBasePath()
+					if err != nil {
+						return err
+					}
+					workDir = basePath
+				}
+
+				env := tasks.NewEnvBuilder().
+					WithGitRoot(gitRoot).
+					WithConfigPath(cfg.ConfigPath).
+					WithBinary(cfg.Binary).
+					Build()
+				taskRunner := tasks.NewRunner(cfg.Tasks, env)
+				return taskRunner.Run(taskFlag, workDir)
+			}
+		}
 
 		if changedFlag {
 			if exampleFlag != "" {
@@ -84,10 +124,14 @@ func listTasks() error {
 
 	for _, name := range names {
 		task := cfg.Tasks[name]
+		label := name
+		if scope := task.EffectiveScope(); scope != tasks.ScopeModule {
+			label = name + " [" + scope + "]"
+		}
 		if task.Description != "" {
-			fmt.Printf("  %-20s %s\n", name, task.Description)
+			fmt.Printf("  %-20s %s\n", label, task.Description)
 		} else {
-			fmt.Printf("  %s\n", name)
+			fmt.Printf("  %s\n", label)
 		}
 	}
 	return nil

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -59,10 +59,16 @@ Examples:
 				if exampleFlag != "" || len(args) > 0 {
 					return fmt.Errorf("cannot use --example or module name with %s-scoped task %q", scope, taskFlag)
 				}
+				if pathFlag != "" {
+					return fmt.Errorf("cannot use --path with %s-scoped task %q", scope, taskFlag)
+				}
 
 				var workDir string
 				switch scope {
 				case tasks.ScopeGit:
+					if gitRoot == "" {
+						return fmt.Errorf("task %q has scope %q but not in a git repository", taskFlag, scope)
+					}
 					workDir = gitRoot
 				case tasks.ScopeRoot:
 					basePath, err := getBasePath()
@@ -74,6 +80,8 @@ Examples:
 
 				env := tasks.NewEnvBuilder().
 					WithGitRoot(gitRoot).
+					WithModulePath("").
+					WithModuleName("").
 					WithConfigPath(cfg.ConfigPath).
 					WithBinary(cfg.Binary).
 					Build()

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -19,7 +19,8 @@ Examples:
   motf test storage-account                    # Run tests on storage-account module
   motf test storage-account -a -v              # Run tests with verbose output
   motf test storage-account -a -timeout=30m    # Run tests with custom timeout`,
-	Args: cobra.MaximumNArgs(1),
+	Args:    cobra.MaximumNArgs(1),
+	PreRunE: requiresBinary,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if changedFlag {
 			if len(args) > 0 {

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -19,7 +19,8 @@ Examples:
   motf val storage-account              # Run validate on storage-account module
   motf val storage-account -e basic     # Run validate on the 'basic' example
   motf val -i storage-account -e basic  # Run init then validate on the 'basic' example`,
-	Args: cobra.MaximumNArgs(1),
+	Args:    cobra.MaximumNArgs(1),
+	PreRunE: requiresBinary,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if changedFlag {
 			if len(args) > 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -619,3 +619,54 @@ func TestLoad_ExplicitConfigPath_RelativePath(t *testing.T) {
 		t.Errorf("expected ConfigPath to be absolute, got '%s'", cfg.ConfigPath)
 	}
 }
+
+func TestLoad_TaskGlobalField(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	gitDir := filepath.Join(tmpDir, ".git")
+	if err := os.Mkdir(gitDir, 0755); err != nil {
+		t.Fatalf("failed to create .git directory: %v", err)
+	}
+
+	configContent := `binary: terraform
+tasks:
+  fmt:
+    command: "terraform fmt -recursive"
+    scope: git
+  lint:
+    command: "tflint"
+    scope: root
+  test:
+    command: "go test ./..."
+`
+	configPath := filepath.Join(tmpDir, ".motf.yml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to create config file: %v", err)
+	}
+
+	cfg, err := Load(tmpDir, "")
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+
+	if cfg.Tasks["fmt"] == nil {
+		t.Fatal("expected 'fmt' task to exist")
+	}
+	if cfg.Tasks["fmt"].Scope != "git" {
+		t.Errorf("expected 'fmt' task scope to be 'git', got %q", cfg.Tasks["fmt"].Scope)
+	}
+
+	if cfg.Tasks["lint"] == nil {
+		t.Fatal("expected 'lint' task to exist")
+	}
+	if cfg.Tasks["lint"].Scope != "root" {
+		t.Errorf("expected 'lint' task scope to be 'root', got %q", cfg.Tasks["lint"].Scope)
+	}
+
+	if cfg.Tasks["test"] == nil {
+		t.Fatal("expected 'test' task to exist")
+	}
+	if cfg.Tasks["test"].Scope != "" {
+		t.Errorf("expected 'test' task scope to be empty (default), got %q", cfg.Tasks["test"].Scope)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -620,7 +620,7 @@ func TestLoad_ExplicitConfigPath_RelativePath(t *testing.T) {
 	}
 }
 
-func TestLoad_TaskGlobalField(t *testing.T) {
+func TestLoad_TaskScopeField(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	gitDir := filepath.Join(tmpDir, ".git")

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -13,6 +13,32 @@ type TaskConfig struct {
 	Description string `yaml:"description"`
 	Shell       string `yaml:"shell"`
 	Command     string `yaml:"command"`
+	Scope       string `yaml:"scope"`
+}
+
+// Task scope constants
+const (
+	ScopeModule = "module"
+	ScopeRoot   = "root"
+	ScopeGit    = "git"
+)
+
+// EffectiveScope returns the task's scope, defaulting to "module" if unset.
+func (tc *TaskConfig) EffectiveScope() string {
+	if tc.Scope == "" {
+		return ScopeModule
+	}
+	return tc.Scope
+}
+
+// ValidateScope returns an error if the scope value is not recognized.
+func (tc *TaskConfig) ValidateScope() error {
+	switch tc.EffectiveScope() {
+	case ScopeModule, ScopeRoot, ScopeGit:
+		return nil
+	default:
+		return fmt.Errorf("unknown scope %q, supported: module, root, git", tc.Scope)
+	}
 }
 
 // ShellConfig defines how to invoke a shell

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -219,7 +219,7 @@ func TestRunner_Run_Errors(t *testing.T) {
 	})
 }
 
-func TestTaskConfig_GlobalField(t *testing.T) {
+func TestTaskConfig_ScopeField(t *testing.T) {
 	t.Run("default scope is module", func(t *testing.T) {
 		tc := &TaskConfig{Command: "echo hello"}
 		if tc.EffectiveScope() != ScopeModule {

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -218,3 +218,42 @@ func TestRunner_Run_Errors(t *testing.T) {
 		}
 	})
 }
+
+func TestTaskConfig_GlobalField(t *testing.T) {
+	t.Run("default scope is module", func(t *testing.T) {
+		tc := &TaskConfig{Command: "echo hello"}
+		if tc.EffectiveScope() != ScopeModule {
+			t.Errorf("expected default scope to be %q, got %q", ScopeModule, tc.EffectiveScope())
+		}
+	})
+
+	t.Run("scope git", func(t *testing.T) {
+		tc := &TaskConfig{Command: "echo hello", Scope: "git"}
+		if tc.EffectiveScope() != ScopeGit {
+			t.Errorf("expected scope %q, got %q", ScopeGit, tc.EffectiveScope())
+		}
+	})
+
+	t.Run("scope root", func(t *testing.T) {
+		tc := &TaskConfig{Command: "echo hello", Scope: "root"}
+		if tc.EffectiveScope() != ScopeRoot {
+			t.Errorf("expected scope %q, got %q", ScopeRoot, tc.EffectiveScope())
+		}
+	})
+
+	t.Run("validate rejects unknown scope", func(t *testing.T) {
+		tc := &TaskConfig{Command: "echo hello", Scope: "unknown"}
+		if err := tc.ValidateScope(); err == nil {
+			t.Error("expected error for unknown scope")
+		}
+	})
+
+	t.Run("validate accepts valid scopes", func(t *testing.T) {
+		for _, scope := range []string{"", "module", "root", "git"} {
+			tc := &TaskConfig{Command: "echo hello", Scope: scope}
+			if err := tc.ValidateScope(); err != nil {
+				t.Errorf("unexpected error for scope %q: %v", scope, err)
+			}
+		}
+	})
+}

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -24,6 +25,23 @@ func NewRunner(cfg *config.Config) *Runner {
 // Binary returns the configured binary name
 func (r *Runner) Binary() string {
 	return r.config.Binary
+}
+
+// CheckBinary verifies the configured binary exists in PATH
+func (r *Runner) CheckBinary() error {
+	_, err := exec.LookPath(r.config.Binary)
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return fmt.Errorf(`'%s' (configured binary) not found in PATH
+
+To fix this, either:
+  - Install terraform: https://terraform.io/downloads
+  - Install tofu: https://opentofu.org/docs/intro/install
+  - Set 'binary: /path/to/terraform' in .motf.yml`, r.config.Binary)
+		}
+		return fmt.Errorf("failed to find %s: %w", r.config.Binary, err)
+	}
+	return nil
 }
 
 // RunInit executes terraform/tofu init in the specified directory

--- a/internal/terraform/terraform_test.go
+++ b/internal/terraform/terraform_test.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/TechnicallyJoe/terraform-motf/internal/config"
@@ -73,6 +74,58 @@ func TestRunner_InheritsConfigBinary(t *testing.T) {
 	cfg.Binary = "terraform"
 	if runner.Binary() != "terraform" {
 		t.Errorf("expected Binary to be 'terraform' after config change, got '%s'", runner.Binary())
+	}
+}
+
+func TestRunner_CheckBinary(t *testing.T) {
+	tests := []struct {
+		name      string
+		binary    string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:    "existing binary (sh)",
+			binary:  "sh",
+			wantErr: false,
+		},
+		{
+			name:      "non-existent binary",
+			binary:    "nonexistent-binary-12345",
+			wantErr:   true,
+			errSubstr: "(configured binary) not found in PATH",
+		},
+		{
+			name:      "error includes install hints",
+			binary:    "nonexistent-tf-binary-xyz",
+			wantErr:   true,
+			errSubstr: "terraform.io/downloads",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Root:   "/test/root",
+				Binary: tt.binary,
+			}
+			runner := NewRunner(cfg)
+			err := runner.CheckBinary()
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("CheckBinary() expected error, got nil")
+					return
+				}
+				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("CheckBinary() error = %q, want substring %q", err.Error(), tt.errSubstr)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("CheckBinary() unexpected error: %v", err)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This pull request introduces support for task scoping (`module`, `root`, `git`) and adds the ability to run `get` and `describe` commands on only changed modules, as well as significant improvements to documentation and end-to-end test coverage. The changes clarify and enforce how tasks are executed based on their scope, update documentation to match new behaviors, and add comprehensive tests to ensure correct handling of new features and edge cases.

**Major new features and changes:**

*Task Scoping and Execution Behavior*
- Added support for `scope` in task definitions (`module`, `root`, `git`), controlling where and how tasks are executed. Tasks with `root` or `git` scope run once from the configured root or git repo root, ignore `--changed`, and cannot be combined with `--example` or a module name. Listing tasks now shows scope indicators for non-module tasks. [[1]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R213-R257) [[2]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180L270-R321) [[3]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R352-R360) [[4]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R48-R52) [[5]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eR493-R516) [[6]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eR530-R532) [[7]](diffhunk://#diff-ea62449b353e74c338844cbfe44eced6def58f8d708169b16248351894938b59R33-R38)

*Changed Modules Support*
- Added `--changed` and `--ref` flags to the `get` and `describe` commands, allowing users to operate only on modules changed compared to a given git ref. Updated documentation and command examples to reflect these new options. [[1]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eL347-R353) [[2]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eR366-R374) [[3]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eL394-R413) [[4]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eR426-R434) [[5]](diffhunk://#diff-28db59191989467fed23e7f87bebccf26e0e37d33fbb273307695650f46a5aa0R49-R66) [[6]](diffhunk://#diff-5d4c8bdb241e94c1fbe48b0364f32b9c7e6e0fe705cc941dbff3d09862409459R32-R57) [[7]](diffhunk://#diff-5d4c8bdb241e94c1fbe48b0364f32b9c7e6e0fe705cc941dbff3d09862409459R6-R7)

*Documentation Updates*
- Expanded documentation in `docs/commands.md` and `docs/configuration.md` to explain task scoping, new flags, environment variable behaviors for scoped tasks, and provided new usage examples for all major changes. [[1]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eL347-R353) [[2]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eR366-R374) [[3]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eL394-R413) [[4]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eR426-R434) [[5]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eR493-R516) [[6]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eR530-R532) [[7]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R213-R257) [[8]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180L270-R321) [[9]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R352-R360) [[10]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R48-R52)

*End-to-End and Unit Test Coverage*
- Added comprehensive end-to-end tests for task scoping behaviors, including correct working directory, ignoring of `--changed`, rejection of incompatible flags, error handling for invalid scopes, and correct listing of task scopes. Also added tests for `get`/`describe --changed` behaviors and flag presence. [[1]](diffhunk://#diff-e91d29c6d4c58503d9c2d72e2b04f1b70901a613e23008d1d1cfe8beff7038d4R1245-R1642) [[2]](diffhunk://#diff-28db59191989467fed23e7f87bebccf26e0e37d33fbb273307695650f46a5aa0R49-R66)

These changes make task execution more flexible and predictable, improve usability for CI and developer workflows, and ensure correctness through extensive documentation and testing.