### PR TITLE
Improve error messages and add validation for task scope

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1489,6 +1489,63 @@ tasks:
 	}
 }
 
+// TestE2E_TaskScope_InvalidScope_List tests that --list fails fast on invalid scope
+func TestE2E_TaskScope_InvalidScope_List(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	configContent := `binary: terraform
+tasks:
+  bad:
+    command: echo hello
+    scope: invalid
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".motf.yml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cmd := exec.Command(motfBinary, "task", "--list")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error for invalid scope in --list, output: %s", output)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "unknown scope") {
+		t.Errorf("expected 'unknown scope' in error, got: %s", outputStr)
+	}
+	if !strings.Contains(outputStr, `"bad"`) {
+		t.Errorf("expected task name 'bad' in error, got: %s", outputStr)
+	}
+}
+
+// TestE2E_TaskScope_NilTask tests that a nil task definition produces an error
+func TestE2E_TaskScope_NilTask(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	configContent := `binary: terraform
+tasks:
+  empty-task:
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".motf.yml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cmd := exec.Command(motfBinary, "task", "--list")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error for nil task, output: %s", output)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "empty definition") {
+		t.Errorf("expected 'empty definition' in error, got: %s", outputStr)
+	}
+}
+
 func TestE2E_DescribeChanged(t *testing.T) {
 	motfBinary := buildMotf(t)
 	tmpDir := setupCleanGitRepo(t)

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -132,6 +132,9 @@ func listTasks() error {
 
 	for _, name := range names {
 		task := cfg.Tasks[name]
+		if task == nil {
+			return fmt.Errorf("task %q has an empty definition in .motf.yml", name)
+		}
 		if err := task.ValidateScope(); err != nil {
 			return fmt.Errorf("task %q: %w", name, err)
 		}

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -132,6 +132,9 @@ func listTasks() error {
 
 	for _, name := range names {
 		task := cfg.Tasks[name]
+		if err := task.ValidateScope(); err != nil {
+			return fmt.Errorf("task %q: %w", name, err)
+		}
 		label := name
 		if scope := task.EffectiveScope(); scope != tasks.ScopeModule {
 			label = name + " [" + scope + "]"

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -37,7 +37,7 @@ func (r *Runner) CheckBinary() error {
 To fix this, either:
   - Install terraform: https://terraform.io/downloads
   - Install tofu: https://opentofu.org/docs/intro/install
-  - Set 'binary: /path/to/terraform' in .motf.yml`, r.config.Binary)
+  - Set 'binary: terraform' or 'binary: tofu' in .motf.yml`, r.config.Binary)
 		}
 		return fmt.Errorf("failed to find %s: %w", r.config.Binary, err)
 	}


### PR DESCRIPTION
This pull request introduces a validation step for task scopes in the CLI and clarifies configuration instructions for specifying the Terraform binary. The most important changes are:

Task validation improvements:
* Added a call to `ValidateScope()` for each task in `listTasks()`, returning an error if a task's scope is invalid. This ensures that only tasks with valid scopes are processed, improving reliability and early error detection.

User guidance update:
* Updated the error message in `CheckBinary()` to clarify that users should set `'binary: terraform'` or `'binary: tofu'` in `.motf.yml`, rather than specifying a full path, making the configuration instructions clearer and more user-friendly.