### PR TITLE
feat(cli): implement apply command with flags and examples

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -205,6 +205,52 @@ motf plan storage-account -a -var="env=prod"
 
 ---
 
+## apply
+
+Run `terraform apply` or `tofu apply` on a module.
+
+```bash
+motf apply <module-name> [flags]
+```
+
+### Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--init` | `-i` | Run init before applying |
+| `--example` | `-e` | Run on a specific example instead of the module |
+| `--changed` | | Run on all modules changed compared to `--ref` |
+| `--ref` | | Git ref to compare against (default: auto-detect) |
+| `--parallel` | `-p` | Run commands in parallel across modules |
+| `--max-parallel` | | Maximum parallel jobs (default: number of CPU cores) |
+
+### Examples
+
+```bash
+# Apply a module
+motf apply storage-account
+
+# Apply with init
+motf apply -i storage-account
+
+# Apply an example
+motf apply storage-account -e basic
+
+# Apply without confirmation prompt
+motf apply storage-account -a -auto-approve
+
+# Apply all changed modules
+motf apply --changed
+
+# Apply all changed modules in parallel
+motf apply --changed --parallel
+
+# Apply with extra arguments
+motf apply storage-account -a -var="env=prod"
+```
+
+---
+
 ## test
 
 Run tests on a module using the configured test engine.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -547,6 +547,21 @@ func TestE2E_FmtChanged_NoOp(t *testing.T) {
 	}
 }
 
+func TestE2E_ApplyChanged_NoOp(t *testing.T) {
+	motfBinary := buildMotf(t)
+	tmpDir := setupCleanGitRepo(t)
+
+	cmd := exec.Command(motfBinary, "apply", "--changed", "--ref", "HEAD")
+	cmd.Dir = tmpDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("motf apply --changed failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(string(output), "No changed modules found") {
+		t.Errorf("expected no-op message, got: %s", output)
+	}
+}
+
 func TestE2E_ListChangedCommand_DetectsUncommitted(t *testing.T) {
 	motfBinary := buildMotf(t)
 	tmpDir := setupCleanGitRepo(t)

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+var applyCmd = &cobra.Command{
+	Use:   "apply [module-name]",
+	Short: "Run terraform/tofu apply on a component, base, or project",
+	Long: `Run terraform/tofu apply on a component, base, or project.
+
+Use the --example/-e flag to run apply on a specific example instead of the module itself.
+
+Examples:
+  motf apply storage-account                   # Run apply on storage-account module
+  motf apply storage-account -e basic          # Run apply on the 'basic' example
+  motf apply -i storage-account                # Run init then apply
+  motf apply storage-account -a -auto-approve  # Apply without confirmation
+  motf apply --changed -a -auto-approve        # Apply all changed modules without confirmation`,
+	Args:    cobra.MaximumNArgs(1),
+	PreRunE: requiresBinary,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if changedFlag {
+			if len(args) > 0 {
+				return cobra.MaximumNArgs(0)(cmd, args)
+			}
+			return runOnChangedModulesWithPath(func(moduleAbsPath string, stdout, stderr io.Writer) error {
+				if initFlag {
+					if err := runner.RunInitWithOutput(moduleAbsPath, stdout, stderr); err != nil {
+						return err
+					}
+				}
+				return runner.RunApplyWithOutput(moduleAbsPath, stdout, stderr, argsFlag...)
+			})
+		}
+
+		targetPath, err := resolveTargetWithExample(args, exampleFlag)
+		if err != nil {
+			return err
+		}
+
+		if initFlag {
+			if err := runner.RunInit(targetPath); err != nil {
+				return err
+			}
+		}
+
+		return runner.RunApply(targetPath, argsFlag...)
+	},
+}
+
+func init() {
+	applyCmd.Flags().BoolVarP(&initFlag, "init", "i", false, "Run init before the command")
+	applyCmd.Flags().StringVarP(&exampleFlag, "example", "e", "", "Run on a specific example instead of the module")
+	applyCmd.Flags().BoolVar(&changedFlag, "changed", false, "Run on modules changed compared to --ref")
+	applyCmd.Flags().StringVar(&refFlag, "ref", "", "Git ref for --changed (default: auto-detect from origin/HEAD)")
+	applyCmd.Flags().BoolVarP(&parallelFlag, "parallel", "p", false, "Run commands in parallel")
+	applyCmd.Flags().IntVar(&maxParallelFlag, "max-parallel", 0, "Maximum parallel jobs (default: number of CPU cores)")
+	rootCmd.AddCommand(applyCmd)
+}

--- a/internal/cli/apply_test.go
+++ b/internal/cli/apply_test.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestApplyCmd_Flags(t *testing.T) {
+	initFlagDef := applyCmd.Flags().Lookup("init")
+	if initFlagDef == nil {
+		t.Fatal("apply command should have --init flag")
+	}
+	if initFlagDef.Shorthand != "i" {
+		t.Errorf("init flag shorthand = %q, want %q", initFlagDef.Shorthand, "i")
+	}
+
+	exampleFlagDef := applyCmd.Flags().Lookup("example")
+	if exampleFlagDef == nil {
+		t.Fatal("apply command should have --example flag")
+	}
+	if exampleFlagDef.Shorthand != "e" {
+		t.Errorf("example flag shorthand = %q, want %q", exampleFlagDef.Shorthand, "e")
+	}
+}

--- a/internal/cli/changed_flags_test.go
+++ b/internal/cli/changed_flags_test.go
@@ -64,3 +64,12 @@ func TestGetCmd_HasChangedFlags(t *testing.T) {
 		t.Fatal("getCmd should have --ref flag")
 	}
 }
+
+func TestApplyCmd_HasChangedFlags(t *testing.T) {
+	if applyCmd.Flags().Lookup("changed") == nil {
+		t.Fatal("applyCmd should have --changed flag")
+	}
+	if applyCmd.Flags().Lookup("ref") == nil {
+		t.Fatal("applyCmd should have --ref flag")
+	}
+}

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -112,6 +112,23 @@ func (r *Runner) RunPlanWithOutput(dir string, stdout, stderr io.Writer, extraAr
 	return cmd.Run()
 }
 
+// RunApply executes terraform/tofu apply in the specified directory
+func (r *Runner) RunApply(dir string, extraArgs ...string) error {
+	return r.RunApplyWithOutput(dir, os.Stdout, os.Stderr, extraArgs...)
+}
+
+// RunApplyWithOutput executes terraform/tofu apply with custom output writers
+func (r *Runner) RunApplyWithOutput(dir string, stdout, stderr io.Writer, extraArgs ...string) error {
+	args := append([]string{"apply"}, extraArgs...)
+	cmd := exec.Command(r.config.Binary, args...) //nolint:gosec // Binary is validated to be terraform or tofu
+	cmd.Dir = dir
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	_, _ = fmt.Fprintf(stdout, "Running %s %s in %s\n", r.config.Binary, strings.Join(args, " "), dir)
+	return cmd.Run()
+}
+
 // RunTest executes tests based on the configured test engine
 func (r *Runner) RunTest(dir string, extraArgs ...string) error {
 	return r.RunTestWithOutput(dir, os.Stdout, os.Stderr, extraArgs...)

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -122,6 +122,7 @@ func (r *Runner) RunApplyWithOutput(dir string, stdout, stderr io.Writer, extraA
 	args := append([]string{"apply"}, extraArgs...)
 	cmd := exec.Command(r.config.Binary, args...) //nolint:gosec // Binary is validated to be terraform or tofu
 	cmd.Dir = dir
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 


### PR DESCRIPTION
This pull request introduces a new `apply` command to the CLI, enabling users to run `terraform apply` or `tofu apply` on modules, with support for several useful flags. The implementation includes command registration, documentation, flag validation, and associated test coverage. Additionally, the underlying Terraform runner is extended to support the new operation.

**New CLI command:**

- Added a new `apply` command (`apply.go`) to the CLI, allowing users to run `terraform/tofu apply` on a module, with flags for initialization, targeting examples, running on changed modules, specifying git refs, and parallel execution.
- Updated documentation in `docs/commands.md` to describe the new `apply` command, its flags, and usage examples.

**Terraform runner enhancements:**

- Added `RunApply` and `RunApplyWithOutput` methods to the Terraform runner in `terraform.go` to execute the apply operation, supporting custom output streams and extra arguments.

**Testing and validation:**

- Added tests for the `apply` command's flags in `apply_test.go` to ensure correct flag registration and shorthands.
- Added tests in `changed_flags_test.go` to verify that the `apply` command includes the `--changed` and `--ref` flags.
- Added an end-to-end test in `e2e_test.go` to verify that `motf apply --changed` is a no-op when no modules have changed.

Closes #49 